### PR TITLE
Add support for html entities and add quote-type preservation

### DIFF
--- a/.changeset/odd-coats-brake.md
+++ b/.changeset/odd-coats-brake.md
@@ -1,0 +1,5 @@
+---
+'@lblod/template-uuid-instantiator': patch
+---
+
+Ensure support for HTML entities and quote-type preservation

--- a/.woodpecker/.release-commit.yml
+++ b/.woodpecker/.release-commit.yml
@@ -1,0 +1,17 @@
+steps:
+  install:
+    image: node:20-slim
+    commands:
+      - npm ci
+  version:
+    image: node:20-slim
+    commands:
+      - npm version --no-git-tag-version $(npm pkg get version | sed 's/"//g')-dev.${CI_COMMIT_SHA}
+  release:
+    image: plugins/npm
+    settings:
+      token:
+        from_secret: npm_access_token
+      tag: dev
+when:
+  - event: push

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This package allows you to instantiate uris of a string.
 
 ## Usage
- 
+
 The utility loops over the text supplied and identifies the strings with the form `"https://example.org/--ref-algorithm-123-456-abc"`, we will explain each part below. It allows both " and ' , as well as HTML entities (such as `&quot;`). Quote types will be preserved.
 
 - Base uri: In the example is the `https://example.org/` part, this part will be preserved in the result uri

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This package allows you to instantiate uris of a string.
 
 ## Usage
-
-The utility loops over the text supplied and identifies the strings with the form `"https://example.org/--ref-algorithm-123-456-abc"`, we will explain each part below. It allows both " and '
+ 
+The utility loops over the text supplied and identifies the strings with the form `"https://example.org/--ref-algorithm-123-456-abc"`, we will explain each part below. It allows both " and ' , as well as HTML entities (such as `&quot;`). Quote types will be preserved.
 
 - Base uri: In the example is the `https://example.org/` part, this part will be preserved in the result uri
 - Uuid: This part is the `--ref-algorithm-123-456-abc` in the example. it has itself 3 parts:

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,16 +40,8 @@ function replacingAlgorithm(
 function curryReplacingAlgorithm(
   memoizationTable: Record<string, MemoizationEntry>,
 ) {
-  return (
-    _: unknown,
-    uuidAlgorithm: string,
-    originalUuid: string,
-  ) => {
-    return replacingAlgorithm(
-      memoizationTable,
-      uuidAlgorithm,
-      originalUuid,
-    );
+  return (_: unknown, uuidAlgorithm: string, originalUuid: string) => {
+    return replacingAlgorithm(memoizationTable, uuidAlgorithm, originalUuid);
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 type AlgorithmFunction = () => string;
 interface MemoizationEntry {
-  uri: string;
+  finalUuid: string;
   uuidAlgorithm: string;
 }
 
@@ -12,29 +12,28 @@ const algorithms: Record<string, AlgorithmFunction> = {
 
 function replacingAlgorithm(
   memoizationTable: Record<string, MemoizationEntry>,
-  uriBase: string,
   uuidAlgorithm: string,
   originalUuid: string,
 ) {
-  const memoizationEntry = memoizationTable[`${uriBase}${originalUuid}`];
+  const memoizationEntry = memoizationTable[originalUuid];
   if (memoizationEntry) {
     if (memoizationEntry.uuidAlgorithm !== uuidAlgorithm) {
       console.warn(
-        `You have 2 entries with the same uri base and uuid, but different algorithm, this is probably and error so the result will be the same uuid in both entries. ${uriBase}--ref-<${uuidAlgorithm}>-${originalUuid} and ${uriBase}--ref-<${memoizationEntry.uuidAlgorithm}>-${originalUuid}`,
+        `You have 2 entries with the same uuid, but different algorithms, this is probably and error so the result will be the same uuid in both entries. --ref-<${uuidAlgorithm}>-${originalUuid} and --ref-<${memoizationEntry.uuidAlgorithm}>-${originalUuid}`,
       );
     }
-    return memoizationTable[`${uriBase}${originalUuid}`].uri;
+    return memoizationTable[originalUuid].finalUuid;
   } else {
     if (!algorithms[uuidAlgorithm]) {
       console.warn(`${uuidAlgorithm} was not recognised, using uuid4 instead`);
     }
     const algorithm = algorithms[uuidAlgorithm] || uuidv4;
-    const finalUri = `"${uriBase}${algorithm()}"`;
-    memoizationTable[`${uriBase}${originalUuid}`] = {
-      uri: finalUri,
+    const finalUuid = algorithm();
+    memoizationTable[originalUuid] = {
+      finalUuid,
       uuidAlgorithm,
     };
-    return finalUri;
+    return finalUuid;
   }
 }
 
@@ -43,13 +42,11 @@ function curryReplacingAlgorithm(
 ) {
   return (
     _: unknown,
-    uriBase: string,
     uuidAlgorithm: string,
     originalUuid: string,
   ) => {
     return replacingAlgorithm(
       memoizationTable,
-      uriBase,
       uuidAlgorithm,
       originalUuid,
     );
@@ -60,7 +57,7 @@ export default function instantiateUuids(templateString: string) {
   const memoizationTable = {};
   const replacingAlgorithmBinded = curryReplacingAlgorithm(memoizationTable);
   return templateString.replace(
-    /["']([^"']+)--ref-([^"'-]+)-([^"']+)["']/g,
+    /--ref-([a-zA-Z0-9]+)-([a-zA-Z0-9-]+)/g,
     replacingAlgorithmBinded,
   );
 }

--- a/tests/instantiate.test.ts
+++ b/tests/instantiate.test.ts
@@ -63,5 +63,7 @@ test('HTML entities are taken into account', () => {
   const example = `<div data-test="{&quot;http://example.net/imported-resource&quot;:&quot;https://example.org/--ref-uuid4-e0109d70-0389-41dd-a517-e1a754bc0ff6&quot;}">`;
 
   const result = instantiateUuids(example);
-  expect(result).toBe(`<div data-test="{&quot;http://example.net/imported-resource&quot;:&quot;https://example.org/uuid-1&quot;}">`)
+  expect(result).toBe(
+    `<div data-test="{&quot;http://example.net/imported-resource&quot;:&quot;https://example.org/uuid-1&quot;}">`,
+  );
 });

--- a/tests/instantiate.test.ts
+++ b/tests/instantiate.test.ts
@@ -58,3 +58,14 @@ test('memoization with different algorithm ignores it', () => {
     <div resource="https://example.org/uuid-1">
   `);
 });
+
+test('HTML entities are taken into account', () => {
+  const example = `
+    <div data-test="{&quot;http://example.net/imported-resource&quot;:&quot;https://example.org/--ref-uuid4-e0109d70-0389-41dd-a517-e1a754bc0ff6&quot;}">
+  `;
+
+  const result = instantiateUuids(example);
+  expect(result).toBe(`
+      <div data-test="{&quot;http://example.net/imported-resource&quot;:&quot;https://example.org/uuid-1&quot;}">
+    `)
+});

--- a/tests/instantiate.test.ts
+++ b/tests/instantiate.test.ts
@@ -44,7 +44,7 @@ test('algorithm defaults to uuid', () => {
 test('works with single quotes', () => {
   const example = `<div resource='https://example.org/--ref-uuid4-bd17cfee-d836-42d1-be3c-9bb1bc276e20'>`;
   const result = instantiateUuids(example);
-  expect(result).toBe(`<div resource="https://example.org/uuid-1">`);
+  expect(result).toBe(`<div resource='https://example.org/uuid-1'>`);
 });
 
 test('memoization with different algorithm ignores it', () => {
@@ -54,18 +54,14 @@ test('memoization with different algorithm ignores it', () => {
   `;
   const result = instantiateUuids(example);
   expect(result).toBe(`
-    <div resource="https://example.org/uuid-1">
-    <div resource="https://example.org/uuid-1">
+    <div resource='https://example.org/uuid-1'>
+    <div resource='https://example.org/uuid-1'>
   `);
 });
 
 test('HTML entities are taken into account', () => {
-  const example = `
-    <div data-test="{&quot;http://example.net/imported-resource&quot;:&quot;https://example.org/--ref-uuid4-e0109d70-0389-41dd-a517-e1a754bc0ff6&quot;}">
-  `;
+  const example = `<div data-test="{&quot;http://example.net/imported-resource&quot;:&quot;https://example.org/--ref-uuid4-e0109d70-0389-41dd-a517-e1a754bc0ff6&quot;}">`;
 
   const result = instantiateUuids(example);
-  expect(result).toBe(`
-      <div data-test="{&quot;http://example.net/imported-resource&quot;:&quot;https://example.org/uuid-1&quot;}">
-    `)
+  expect(result).toBe(`<div data-test="{&quot;http://example.net/imported-resource&quot;:&quot;https://example.org/uuid-1&quot;}">`)
 });


### PR DESCRIPTION
### Overview
This PR includes a few modifications to the regex which detects the template URIs in a template:
- It no longer matches the URI base, and only matches the `--ref-${algo}-${uuid}` part.
- It preserves quote types (`'` stays `'`, `"` stays `"`, `&quot;` stays `&quot;` etc.)

This PR adds a test to verify support of HTML entities (https://developer.mozilla.org/en-US/docs/Glossary/Character_reference).

### How to test/reproduce
- The tests should be successful of course :)
- Instructions to test on GN: https://github.com/lblod/frontend-gelinkt-notuleren/pull/772

### Challenges/uncertainties
- The regex no longer matches on the URI base, this didn't seem necessary to me, and correctly regex matching a URI base is both prone to errors and quite unreadable.
